### PR TITLE
Remove confusing paragraph in README regarding post redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,11 +110,7 @@ Pon especial atención en que el callback `authorized` recibirá 2 parámetros d
 authorized: function (occ, externalUniqueNumber) {}
 ```
 
-Para invocar a tu backend enviando estos dos parámetros puedes hacer un redirect vía POST o usando XHR.
-
-En nuestro ejemplo hemos llamado a la función `sendHttpPostRedirect("./transaction-commit.html", occ, externalUniqueNumber)`
-por temas de claridad no hemos puesto la definición e implementación de esta función ya que no es parte del SDK
-y queda en tus manos el decidir su implementación.
+Para invocar a tu backend enviando estos dos parámetros puedes hacer un redirect vía POST o usar XHR (también conocido como AJAX).
 
 ### Instanciar librería y dibujar QR
 


### PR DESCRIPTION
As it's now, the paragraph points to an "example" without making clear 
where the reader can find such example nor the function referenced.

I could have tried to fix that and link to the example projects. But I see
little point on doing that as the previous line (which talks about POSTing
or sending the key information to the backend) already documents the
expected behavior.